### PR TITLE
adding replSet option lookup to mongodb base template

### DIFF
--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -71,7 +71,9 @@ master = <%= scope.function_options_lookup(['master','false']) %>
 <% if  scope.function_options_lookup(['slave','false']) == true %>
 slave = <%= scope.function_options_lookup(['slave','false']) %>
 source = <%= scope.function_options_lookup(['source','']) %>
+ <% if scope.function_options_lookup(['replicaset','']) == '' %>
 only = <%= scope.function_options_lookup(['only','']) %>
+ <% end %>
 <% end %>
 
 # slaveDelay = <%= scope.function_options_lookup(['slaveDelay','0']) %>


### PR DESCRIPTION
This is a minor change for the mongodb conf template to add the replSet option. I know this is in an old branch but for the ones that are still using an old puppet version this is needed.
Thanks
